### PR TITLE
feat: patroni

### DIFF
--- a/helm/keycloak/values-c6af30-dev.yaml
+++ b/helm/keycloak/values-c6af30-dev.yaml
@@ -1,9 +1,11 @@
 replicaCount: 3
 
 project: sso-keycloak
+nameOverride: sso-keycloak
+fullnameOverride: sso-keycloak
 
 image:
-  tag: dev
+  tag: 7.5-9-rc.2
 
 service:
   type: ClusterIP
@@ -11,10 +13,11 @@ service:
 
 postgres:
   host: sso-patroni
+  database: ssokeycloak
   credentials:
     secret: sso-patroni
-    usernameKey: username-superuser
-    passwordKey: password-superuser
+    usernameKey: username-appuser
+    passwordKey: password-appuser
 
 tls:
   enabled: true

--- a/helm/patroni/values-c6af30-dev-sso-patroni.yaml
+++ b/helm/patroni/values-c6af30-dev-sso-patroni.yaml
@@ -12,6 +12,10 @@ fullnameOverride: sso-patroni
 auth:
   existingSecret: sso-patroni
 
+appdb:
+  create: true
+  dbname: ssokeycloak
+
 env:
   ALLOW_NOSSL: "true"
 
@@ -29,3 +33,9 @@ kubernetes:
     enable: true
 walE:
   enable: false
+
+# auth:
+#   existingSecret: sso-patroni
+#   superuser:
+#     username: username-superuser
+#     password: password-superuser


### PR DESCRIPTION
These helm charts are not running.  These are the steps I took to deploy these charts to try and deploy keycloak.  I'm not clear on what's going wrong.

# In the patroni folder

make uninstall NAME=sso-patroni NAMESPACE=c6af30-dev
helm delete sso-patroni
kubectl delete pvc -l release=sso-patroni
kubectl delete configmaps -l release=sso-patroni

## Delete the sso-patroni secret

make uninstall NAMESPACE=c6af30-dev

## Generate the secrete 

make create-random-db-secret NAME=sso-patroni NAMESPACE=c6af30-dev

## Create the database

make install NAME=sso-patroni NAMESPACE=c6af30-dev

# In the keycloak folder:

make install NAMESPACE=c6af30-dev
