### PR TITLE
chore: document

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,6 +46,8 @@ Scripts to manage Keycloak realms and configurations
 
 - Delete a custom realm
 
+  **WARNING: This is almost impossible to revert. Before deleting a custom realm, deactivate it in the dev test an and prod environments for a few days as a final safeguard to make sure it's not in use by other projects.**
+
   - Workflow
 
     1.  Find all IDPs associated with this realm


### PR DESCRIPTION
Add a warning to the deletion readme as a precaution.

As discussed in last week's ops meeting I've put an extra step in the deletion of custom realms to help prevent us from removing a realm that's in use.  