### PR TITLE
feat: addclient

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: prettier
         name: Format js files with prettier
-        files: "scripts/.*$, docker/kc-cron-job/.*$"
+        files: "scripts/.*$|docker/kc-cron-job/.*$"
   # - repo: local
   #   hooks:
   #     - id: java-formatter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: prettier
         name: Format js files with prettier
-        files: scripts/.*$, docker/kc-cron-job/.
+        files: scripts/.*$|docker/kc-cron-job/.*$
   # - repo: local
   #   hooks:
   #     - id: java-formatter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: prettier
         name: Format js files with prettier
-        files: scripts/.*$, docker/kc-cron-job/.*$
+        files: scripts/.*$, docker/kc-cron-job/.
   # - repo: local
   #   hooks:
   #     - id: java-formatter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: prettier
         name: Format js files with prettier
-        files: "scripts/.*$|docker/kc-cron-job/.*$"
+        files: scripts/.*$, docker/kc-cron-job/.*$
   # - repo: local
   #   hooks:
   #     - id: java-formatter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: prettier
         name: Format js files with prettier
-        files: "scripts/.*$"
+        files: "scripts/.*$, docker/kc-cron-job/.*$"
   # - repo: local
   #   hooks:
   #     - id: java-formatter

--- a/docker/kc-cron-job/active-sessions.js
+++ b/docker/kc-cron-job/active-sessions.js
@@ -42,23 +42,20 @@ async function main() {
         const sessions = await kcAdminClient.sessions.find({
           realm: realm.realm,
         });
-      sessions.map( (session) => {
-        const sessionActiveCount=parseInt(session.active);
-        const sessionClientID= session.clientId;
-        if (sessionActiveCount>0) {
-          dataset.push([
-            KEYCLOAK_URL,
-            realm.realm,
-            sessionClientID,
-            sessionActiveCount
-          ])
-        }
-      })
-
+        sessions.map((session) => {
+          const sessionActiveCount = parseInt(session.active);
+          const sessionClientID = session.clientId;
+          if (sessionActiveCount > 0) {
+            dataset.push([KEYCLOAK_URL, realm.realm, sessionClientID, sessionActiveCount]);
+          }
+        });
       }),
     );
 
-    const query = format('INSERT INTO active_sessions (keycloak_url, realm, client_id, session_count) VALUES %L', dataset);
+    const query = format(
+      'INSERT INTO active_sessions (keycloak_url, realm, client_id, session_count) VALUES %L',
+      dataset,
+    );
 
     await client.connect();
     await client.query(query);

--- a/docker/kc-cron-job/active-sessions.js
+++ b/docker/kc-cron-job/active-sessions.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const { Client } = require('pg');
 const format = require('pg-format');
 const KcAdminClient = require('keycloak-admin').default;
+
 const KEYCLOAK_URL = process.env.KEYCLOAK_URL || 'https://dev.oidc.gov.bc.ca';
 const KEYCLOAK_CLIENT_ID = process.env.KEYCLOAK_CLIENT_ID || 'script-cli';
 const KEYCLOAK_CLIENT_SECRET = process.env.KEYCLOAK_CLIENT_SECRET;
@@ -23,6 +24,7 @@ async function main() {
       clientId: KEYCLOAK_CLIENT_ID,
       clientSecret: KEYCLOAK_CLIENT_SECRET,
     });
+
     // see https://node-postgres.com/api/client#new-clientconfig-object
     const client = new Client({
       host: PGHOST,

--- a/docker/kc-cron-job/active-sessions.js
+++ b/docker/kc-cron-job/active-sessions.js
@@ -49,8 +49,8 @@ async function main() {
           dataset.push([
             KEYCLOAK_URL,
             realm.realm,
-            sessionActiveCount,
-            sessionClientID
+            sessionClientID,
+            sessionActiveCount
           ])
         }
       })
@@ -58,7 +58,7 @@ async function main() {
       }),
     );
 
-    const query = format('INSERT INTO active_sessions (keycloak_url, realm, session_count, client_id) VALUES %L', dataset);
+    const query = format('INSERT INTO active_sessions (keycloak_url, realm, client_id, session_count) VALUES %L', dataset);
 
     await client.connect();
     await client.query(query);

--- a/helm/kc-cron-job/templates/cron-active-sessions.yaml
+++ b/helm/kc-cron-job/templates/cron-active-sessions.yaml
@@ -35,6 +35,7 @@ spec:
                         keycloak_url varchar(1000),
                         realm varchar(1000),
                         session_count int,
+                        client_id varchar(1000),
                         created_at timestamp with time zone default current_timestamp,
                         primary key(id)
                     );


### PR DESCRIPTION
This PR adds the client ID to the database active sessions.  
The collumn 'client_id' was manually added to the gold sandbox, gold prod, and silver prod using:
`ALTER TABLE active_sessions ADD client_id varchar(1000);`
Next time the cron job is triggered the active sessions will have a client id
Note anything before today will have a null client_id