### PR TITLE
Bump annotation

### DIFF
--- a/helm/keycloak/README.md
+++ b/helm/keycloak/README.md
@@ -66,7 +66,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `nodeSelector`                       | node labels for pod assignment                 | `{}`                                                                                       |
 | `tolerations`                        | toleration settings                            | `[]`                                                                                       |
 | `affinity`                           | affinity settings                              | `{}`                                                                                       |
-
+| `annotations.timeout`                | route timeout                                  | null                                                                                       |
 ### Notes
 
 - The helm chart installs two `Secret` k8s objects:

--- a/helm/keycloak/templates/route.yaml
+++ b/helm/keycloak/templates/route.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
     haproxy.router.openshift.io/disable_cookies: 'true'
+    {{ if .Values.annotations.timeout }}
+    haproxy.router.openshift.io/timeout: {{ .Values.annotations.timeout }}
+    {{ end }}
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/helm/keycloak/values-3d5c3f-prod.yaml
+++ b/helm/keycloak/values-3d5c3f-prod.yaml
@@ -15,6 +15,9 @@ postgres:
     usernameKey: app-db-username
     passwordKey: app-db-password
 
+annotations:
+  timeout: 60s
+
 tls:
   enabled: true
 

--- a/helm/keycloak/values-3d5c3f-prod.yaml
+++ b/helm/keycloak/values-3d5c3f-prod.yaml
@@ -1,7 +1,9 @@
-replicaCount: 1
+replicaCount: 7
+
+project: sso-keycloak
 
 image:
-  tag: 7.4-37-rc.2
+  tag: 7.4-37-rc.3
 
 service:
   type: ClusterIP
@@ -24,7 +26,7 @@ tls:
 resources:
   limits:
     cpu: 2
-    memory: 2Gi
+    memory: 4Gi
   requests:
-    cpu: 1250m
-    memory: 2Gi
+    cpu: 250m
+    memory: 4Gi

--- a/helm/keycloak/values-6d70e7-prod.yaml
+++ b/helm/keycloak/values-6d70e7-prod.yaml
@@ -17,6 +17,9 @@ postgres:
     usernameKey: username
     passwordKey: password
 
+annotations:
+  timeout: 60s
+
 persistentLog:
   storageClassSize: 15Gi
 

--- a/helm/keycloak/values.yaml
+++ b/helm/keycloak/values.yaml
@@ -38,6 +38,9 @@ postgres:
     min: 5
     max: 20
 
+annotations:
+  timeout: null
+
 # see https://github.com/keycloak/keycloak-containers/blob/master/server/README.md#start-a-keycloak-instance-with-custom-command-line-options
 additionalServerOptions: "-Dkeycloak.profile.feature.authorization=enabled -Djboss.persistent.log.dir=/var/log/eap"
 


### PR DESCRIPTION
- sandbox has been upgraded to more closely resemble silver prod (for future load testing)
- The timeout is added to the annotation making sure we can easily increase it (if only this changes the keycloak pods don't cycle)
- The default null ensures the other deployments in silver are unnafected by this change