### PR TITLE
feat: add optional tooltips for idp selections

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,11 +6,11 @@ jobs:
   pre-commit:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install asdf
         uses: asdf-vm/actions/setup@v1
       - name: Cache tools
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             /home/runner/.asdf
@@ -26,10 +26,11 @@ jobs:
           pip install -r requirements.txt
           asdf reshim
           pre-commit run --color=always --show-diff-on-failure --all-files
+
   commitlint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v2
+      - uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/publish-image-backup-storage-test.yml
+++ b/.github/workflows/publish-image-backup-storage-test.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-image-kc-cron-job.yml
+++ b/.github/workflows/publish-image-kc-cron-job.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/docker/keycloak/extensions-7.6/services/pom.xml
+++ b/docker/keycloak/extensions-7.6/services/pom.xml
@@ -51,6 +51,25 @@
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.14.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.14.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.14.0</version>
+                <scope>provided</scope>
+            </dependency>
+
             <!-- Tests -->
             <dependency>
                 <groupId>junit</groupId>

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc-ext.html
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc-ext.html
@@ -5,3 +5,10 @@
     </div>
     <kc-tooltip>Does the external IDP support legacy logout redirect URI (redirect_uri)?</kc-tooltip>
 </div>
+<div class="form-group">
+    <label class="col-md-2 control-label" for="tooltip">Tooltip</label>
+    <div class="col-md-6">
+        <input ng-model="identityProvider.config.tooltip" id="tooltip" type="text" class="form-control"/>
+    </div>
+    <kc-tooltip>IDP tooltip to show on the login screen.</kc-tooltip>
+</div>

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov-idp-stopper/login/login.ftl
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov-idp-stopper/login/login.ftl
@@ -2,7 +2,7 @@
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
     <#if section = "header">
         ${msg("loginAccountTitle")}
-    <#elseif section = "info" >
+    <#elseif section = "info">
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
             <div id="kc-registration-container">
                 <div id="kc-registration">
@@ -11,15 +11,39 @@
                 </div>
             </div>
         </#if>
-    <#elseif section = "socialProviders" >
+    <#elseif section = "socialProviders">
         <#if realm.password && social.providers??>
             <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
                 <ul class="kc-social-links">
+                    <#assign idpContext = login.username?eval_json>
                     <#list social.providers as p>
-                        <#if login.username?contains("##" + p.alias + "##")>
+                        <#if idpContext[p.alias]?has_content && idpContext[p.alias]["enabled"] == "true">
+                        <li class="kc-social-link">
                             <a id="social-${p.alias}" class="bcgov-primary mb-2" type="button" href="${p.loginUrl}">
                                 <span class="${properties.kcFormSocialAccountNameClass!}">${p.displayName!}</span>
                             </a>
+                            <#if idpContext[p.alias]["tooltip"]?has_content>
+                            <span class="kc-social-icon" data-tooltip="${idpContext[p.alias]["tooltip"]}">
+                                <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
+                                    data-icon="circle-info"
+                                    class="svg-inline--fa fa-circle-info"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512"
+                                    color="#777777"
+                                >
+                                    <path
+                                        fill="currentColor"
+                                        d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-144c-17.7 0-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32s-14.3 32-32 32z"
+                                    >
+                                    </path>
+                                </svg>
+                            </span>
+                            </#if>
+                        </li>
                         </#if>
                     </#list>
                 </ul>

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov-idp-stopper/login/theme.properties
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov-idp-stopper/login/theme.properties
@@ -1,3 +1,2 @@
 parent=bcgov
-import=common/keycloak
 kcLoginTitleType=client

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov-no-header-no-footer/login/theme.properties
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov-no-header-no-footer/login/theme.properties
@@ -1,0 +1,3 @@
+parent=bcgov
+kcShowHeader=false
+kcShowFooter=false

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/resources/css/styles.css
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/resources/css/styles.css
@@ -62,9 +62,7 @@
 .login-pf body .login-pf-page #kc-content #kc-content-wrapper #kc-form-wrapper {
   width: 100%;
   margin-bottom: 20px;
-  border-bottom: 1px solid #b3b1b3;
   border-right: none;
-  padding: 10px 20px;
 }
 
 .login-pf body .login-pf-page #kc-content #kc-content-wrapper #kc-error-message {
@@ -73,6 +71,23 @@
   text-align: center;
   border: 2px solid red;
   border-radius: 5px;
+}
+
+.login-pf body .login-pf-page #kc-content #kc-content-wrapper .kc-social-provider-name {
+  top: 0;
+}
+
+.login-pf body .login-pf-page #kc-content #kc-content-wrapper .kc-social-link {
+  display: flex;
+}
+
+.login-pf body .login-pf-page #kc-content #kc-content-wrapper .kc-social-link > a {
+  width: 100%;
+}
+
+.login-pf body .login-pf-page #kc-content #kc-content-wrapper .kc-social-link > span {
+  width: 40px;
+  padding: 6px;
 }
 
 /* HEADER */
@@ -156,6 +171,8 @@
 }
 
 /* BCGOV PRIMARY BUTTON */
+#kc-form-buttons input,
+#kc-social-providers .kc-social-links a[type='button'],
 .bcgov-primary {
   background-color: #003366;
   border: none;
@@ -172,17 +189,44 @@
   cursor: pointer;
 }
 
+#kc-form-buttons input {
+  padding: 0.4rem 0.5rem;
+}
+
+#kc-form-buttons input:hover,
+#kc-social-providers .kc-social-links a[type='button']:hover,
 .bcgov-primary:hover {
   color: white !important;
   text-decoration-line: none;
+  border: none;
+  border-radius: 4px;
   opacity: 0.8;
 }
 
+#kc-form-buttons input:after,
+#kc-social-providers .kc-social-links a[type='button']:after,
+.bcgov-primary:after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  content: '';
+  border: none;
+  border-color: transparent;
+  border-radius: 4px;
+}
+
+#kc-form-buttons input:focus,
+#kc-social-providers .kc-social-links a[type='button']:focus,
 .bcgov-primary:focus {
   outline: 4px solid #3b99fc;
   outline-offset: 1px;
 }
 
+#kc-form-buttons input:active,
+#kc-social-providers .kc-social-links a[type='button']:active,
 .bcgov-primary:active {
   opacity: 1;
 }

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/resources/js/script.js
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/resources/js/script.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', function (event) {
   const errorElem = document.getElementById('kc-error-message');
   const titleContent = errorElem ? 'Login Error:' : 'Authenticate with:';
   document.getElementById('kc-page-title').innerHTML = titleContent;
+
+  addTooltips();
 });
 
 function updateFavIcon() {
@@ -13,4 +15,22 @@ function updateFavIcon() {
   link.rel = 'shortcut icon';
   link.href = 'https://portal.nrs.gov.bc.ca/nrs-portal-theme/images/favicon.ico';
   document.getElementsByTagName('head')[0].appendChild(link);
+}
+
+function addTooltips() {
+  const icons = document.getElementsByClassName('kc-social-icon');
+  for (var x = 0; x < icons.length; x++) {
+    var elem = icons[x];
+    var content = elem.getAttribute('data-tooltip');
+
+    if (content) {
+      tippy(elem, {
+        content,
+        allowHTML: true,
+        hideOnClick: false,
+        delay: [100, 100],
+        interactive: true,
+      });
+    }
+  }
 }

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/template.ftl
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/template.ftl
@@ -29,6 +29,11 @@
             <script src="${url.resourcesPath}/${script}" type="text/javascript"></script>
         </#list>
     </#if>
+    <#if properties.absoluteScripts?has_content>
+        <#list properties.absoluteScripts?split(' ') as script>
+            <script src="${script}" type="text/javascript"></script>
+        </#list>
+    </#if>
     <#if scripts??>
         <#list scripts as script>
             <script src="${script}" type="text/javascript"></script>
@@ -38,6 +43,7 @@
 
 <body class="${properties.kcBodyClass!}">
 
+<#if properties.kcShowHeader == "true">
 <header>
   <div class="banner">
     <span></span>
@@ -45,6 +51,7 @@
   </div>
   <div class="other">&nbsp;</div>
 </header>
+</#if>
 
 <div class="${properties.kcLoginClass!}">
     <div id="kc-header" class="${properties.kcHeaderClass!}">
@@ -162,6 +169,7 @@
       </div>
     </div>
   </div>
+  <#if properties.kcShowFooter == "true">
   <footer class="footer">
     <div class="list">
       <ul>
@@ -172,6 +180,7 @@
       </ul>
     </div>
   </footer>
+  </#if>
 </body>
 </html>
 </#macro>

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/theme.properties
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/theme.properties
@@ -2,5 +2,8 @@ parent=keycloak
 import=common/keycloak
 styles=css/login.css css/tile.css css/bcsans.css css/styles.css
 scripts=js/script.js
+absoluteScripts=https://unpkg.com/@popperjs/core@2 https://unpkg.com/tippy.js@6
 
 kcLoginTitleType=realm
+kcShowHeader=true
+kcShowFooter=true

--- a/helm/keycloak/values-b861c7-test-4.yaml
+++ b/helm/keycloak/values-b861c7-test-4.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/bcgov/sso
-  tag: 7.6.5-build.16
+  tag: 7.6.5-build.18
   pullPolicy: IfNotPresent
 
 rollingUpdate:

--- a/helm/keycloak/values-b861c7-test-5.yaml
+++ b/helm/keycloak/values-b861c7-test-5.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/bcgov/sso
-  tag: 7.6.5-build.16
+  tag: 7.6.5-build.18
   pullPolicy: IfNotPresent
 
 rollingUpdate:

--- a/helm/keycloak/values-b861c7-test-6.yaml
+++ b/helm/keycloak/values-b861c7-test-6.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/bcgov/sso
-  tag: 7.6.5-build.16
+  tag: 7.6.5-build.18
   pullPolicy: IfNotPresent
 
 rollingUpdate:


### PR DESCRIPTION
- add an option in the `identify provider` configuration page to display tooltips in the login page
- update and create two `bcgov` themes that can be used for custom realms
- bump deprecated GitHub action versions