### PR TITLE
feat: sso security patch through 7.6-25

### DIFF
--- a/docker/keycloak/Dockerfile-7.6
+++ b/docker/keycloak/Dockerfile-7.6
@@ -5,7 +5,7 @@ WORKDIR /tmp/
 RUN mvn -B clean package --file pom.xml
 
 # see https://catalog.redhat.com/software/containers/rh-sso-7/sso76-openshift-rhel8/629651e2cddbbde600c0a2ec
-FROM registry.redhat.io/rh-sso-7/sso76-openshift-rhel8:7.6-17
+FROM registry.redhat.io/rh-sso-7/sso76-openshift-rhel8:7.6-25
 
 ENV CONFIGURATION /opt/eap/standalone/configuration
 

--- a/docker/keycloak/configuration/standalone-openshift-7.6.xml
+++ b/docker/keycloak/configuration/standalone-openshift-7.6.xml
@@ -410,14 +410,16 @@
                 <local-cache name="authorization">
                     <heap-memory size="10000" />
                 </local-cache>
-                <replicated-cache name="work" />
+                <replicated-cache name="work">
+                    <expiration lifespan="900000000000000000"/>
+                </replicated-cache>
                 <local-cache name="keys">
                     <heap-memory size="1000" />
                     <expiration max-idle="3600000" />
                 </local-cache>
                 <distributed-cache name="actionTokens" owners="${env.CACHE_OWNERS_COUNT:2}">
                     <heap-memory size="-1" />
-                    <expiration max-idle="-1" interval="300000" />
+                    <expiration max-idle="-1" lifespan="900000000000000000" interval="300000" />
                 </distributed-cache>
             </cache-container>
             <cache-container name="ejb" default-cache="repl" aliases="sfsb" modules="org.wildfly.clustering.ejb.infinispan">

--- a/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/CookieStopAuthenticator.java
+++ b/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/CookieStopAuthenticator.java
@@ -48,26 +48,9 @@ public class CookieStopAuthenticator implements Authenticator {
       return;
     }
 
-    // 3. if user has existing session with a different client in same realm then
-    // attach the existing session to the user
-
-    String sessionIdp = authResult.getSession().getNotes().get("identity_provider");
-    Map<String, ClientScopeModel> currentClientScopes = context.getAuthenticationSession().getClient()
-        .getClientScopes(true);
-
-    for (Map.Entry<String, ClientScopeModel> entry : currentClientScopes.entrySet()) {
-      if (entry.getKey().equalsIgnoreCase(sessionIdp)) {
-        context.getAuthenticationSession().setAuthNote(AuthenticationManager.SSO_AUTH,
-            "true");
-        context.attachUserSession(authResult.getSession());
-        context.success();
-        return;
-      }
-    }
-
     MultivaluedMap<String, String> queryParams = context.getUriInfo().getQueryParameters();
 
-    // 4. If a target IDP is passed via "kc_idp_hint" query param, and
+    // 3. If a target IDP is passed via "kc_idp_hint" query param, and
     // i. the target IDP is enabled;
     // ii. the target IDP is allowed for the authenticating client;
     // iii. the target IDP is different one than the one in the user session;
@@ -96,16 +79,15 @@ public class CookieStopAuthenticator implements Authenticator {
     AuthenticatedClientSessionModel clientSessionModel = authResult.getSession()
         .getAuthenticatedClientSessionByClient(clientUUID);
 
-    // 5. If no Cookie session with the authenticating client, proceed to login
+    // 4. If no Cookie session with the authenticating client, proceed to login
     // process
     if (clientSessionModel == null) {
       context.attempted();
       return;
     }
 
-    // 6. Otherwise, attach the exisiting session to the user
-    context.getAuthenticationSession().setAuthNote(AuthenticationManager.SSO_AUTH,
-        "true");
+    // 5. Otherwise, attach the exisiting session to the user
+    context.getAuthenticationSession().setAuthNote(AuthenticationManager.SSO_AUTH, "true");
     context.setUser(authResult.getUser());
     context.attachUserSession(authResult.getSession());
     context.success();

--- a/scripts/restore-idir-users-with-roles.js
+++ b/scripts/restore-idir-users-with-roles.js
@@ -1,0 +1,118 @@
+const { getAdminClient } = require('./keycloak-core');
+const fs = require('fs');
+const path = require('path');
+const { argv } = require('yargs');
+const { env, json } = argv;
+const { readJSON } = require('./utils');
+
+const processed = [];
+const unprocessed = [];
+
+const basePath = path.join(__dirname, 'exports');
+
+const restoreUsers = async () => {
+  if (!env || !json) {
+    console.info(`
+    Usages:
+      node restore-idir-users-with-roles.js --env <env> --json <jsonfile>
+    `);
+
+    return;
+  }
+
+  const totalUsers = readJSON(`${__dirname}/${json}`);
+
+  for (let kuser of totalUsers) {
+    try {
+      kuser.attributes = JSON.parse(kuser.attributes);
+      kuser.realm_roles = kuser.realm_roles.slice(1, -1).split(',');
+      let clientRoles = JSON.parse('[' + kuser.client_roles.slice(1, -1) + ']');
+      kuser.client_roles = clientRoles.map((ob) => JSON.parse(ob));
+
+      const keycloakAdmin = await getAdminClient(env);
+
+      let newUser = null;
+
+      const us = await keycloakAdmin.users.find({ realm: 'standard', username: kuser.username, max: 1 });
+
+      if (us.length === 0) {
+        const createdUser = await keycloakAdmin.users.create({
+          realm: 'standard',
+          username: kuser.username,
+          email: kuser.email,
+          enabled: true,
+          firstName: kuser.first_name,
+          lastName: kuser.last_name,
+          attributes: kuser.attributes,
+          realmRoles: kuser.realm_roles,
+        });
+        newUser = createdUser;
+      } else {
+        newUser = us[0];
+      }
+
+      const fedList = await keycloakAdmin.users.listFederatedIdentities({ realm: 'standard', id: newUser.id });
+
+      if (fedList.length === 0) {
+        await keycloakAdmin.users.addToFederatedIdentity({
+          realm: 'standard',
+          id: newUser.id,
+          federatedIdentityId: 'idir',
+          federatedIdentity: {
+            userId: kuser.username.split('@')[0],
+            userName: kuser.username.split('@')[0],
+            identityProvider: 'idir',
+          },
+        });
+      }
+
+      if (kuser.client_roles !== '') {
+        for (cl of kuser.client_roles) {
+          const clients = await keycloakAdmin.clients.find({
+            realm: 'standard',
+            clientId: cl.client,
+            max: 1,
+          });
+
+          let croles = [];
+
+          for (role of cl.roles) {
+            const r = await keycloakAdmin.clients.findRole({
+              realm: 'standard',
+              id: String(clients[0].id),
+              roleName: role,
+            });
+            croles.push({ id: r.id, name: r.name });
+          }
+
+          const roleMapping = {
+            realm: 'standard',
+            id: newUser.id,
+            clientUniqueId: String(clients[0].id),
+          };
+
+          const roleMappingUpdate = {
+            ...roleMapping,
+            roles: croles,
+          };
+
+          await keycloakAdmin.users.addClientRoleMappings(roleMappingUpdate);
+        }
+      }
+      processed.push(kuser);
+      console.log('processed', processed.length);
+    } catch (err) {
+      unprocessed.push(kuser);
+      console.log('unprocessed', unprocessed.length);
+      continue;
+    }
+  }
+
+  if (!fs.existsSync(basePath)) fs.mkdirSync(basePath);
+  fs.writeFileSync(
+    path.resolve(basePath, `restore-${env}-${new Date().getTime()}.json`),
+    JSON.stringify({ processed, unprocessed }, null, 2),
+  );
+};
+
+restoreUsers();

--- a/scripts/restore-idir-users-with-roles.js
+++ b/scripts/restore-idir-users-with-roles.js
@@ -13,8 +13,15 @@ const basePath = path.join(__dirname, 'exports');
 const restoreUsers = async () => {
   if (!env || !json) {
     console.info(`
+    Pre-requisites:
+      * Run SELECT * FROM KC_DELETED_USERS WHERE TIMESTAMP > CURRENT_DATE AND ENVIRONMENT = <env>; to fetch deleted user data by environment
+      * Save the output in JSON format and place it under <root>/scripts folder
+
     Usages:
       node restore-idir-users-with-roles.js --env <env> --json <jsonfile>
+
+    Examples:
+      node restore-idir-users-with-roles.js --env dev --json dev-users.json
     `);
 
     return;


### PR DESCRIPTION
- Updating the keycloak dockerfile to use [SSO 7.6-25](https://catalog.redhat.com/software/containers/rh-sso-7/sso76-openshift-rhel8/629651e2cddbbde600c0a2ec)
- Rolling back the fix added for [SSOTEAM-608](https://bcdevex.atlassian.net/browse/SSOTEAM-608)
- Adding a script to restore users that are deleted by [remove-inactive-idir-users](https://github.com/bcgov/sso-keycloak/blob/dev/docker/kc-cron-job/remove-inactive-idir-users.js)

