### PR TITLE
feat: custom messages for two login errors

### DIFF
--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/messages/messages_en.properties
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/messages/messages_en.properties
@@ -5,5 +5,5 @@ loginTotpStep1=Install one of the following applications on your mobile, desktop
 configureTotpMessage=You need to set up either a mobile, desktop or browser authenticator to activate your account.
 missingTotpMessage=Please specify One-time code.
 kcLabelWrapperClass=col-md-4
-invalidFederatedIdentityActionMessage=You cannot log in to both IDIR and BCeID at the same time in one browser. Learn more <a href="#">here</a>.
+invalidFederatedIdentityActionMessage=<b>Unexpected error has occured:</b><br />you are already logged into IDIR or BCeID and you need to logout or use fresh browser to continue. Visit <a href="https://github.com/bcgov/sso-keycloak/wiki/Our-Partners-and-Useful-Information#common-login-errors">here</a> to learn more.
 differentUserAuthenticated=You have authenticated/logged in with a different identity provider <span class="login-err-username"><{0}></span> . Please <a class="instruction-link" href="#">sign out</a> if you want to continue.

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/messages/messages_en.properties
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/messages/messages_en.properties
@@ -5,5 +5,5 @@ loginTotpStep1=Install one of the following applications on your mobile, desktop
 configureTotpMessage=You need to set up either a mobile, desktop or browser authenticator to activate your account.
 missingTotpMessage=Please specify One-time code.
 kcLabelWrapperClass=col-md-4
-invalidFederatedIdentityActionMessage=<b>Unexpected error has occured:</b><br />you are already logged into IDIR or BCeID and you need to logout or use fresh browser to continue. Visit <a href="https://github.com/bcgov/sso-keycloak/wiki/Our-Partners-and-Useful-Information#common-login-errors">here</a> to learn more.
+invalidFederatedIdentityActionMessage=An unexpected error has occurred or you are already logged into IDIR or BCeID and you need to logout or use a fresh browser to continue. Visit <a href="https://github.com/bcgov/sso-keycloak/wiki/Our-Partners-and-Useful-Information#common-login-errors">here</a> to learn more.
 differentUserAuthenticated=You have authenticated/logged in with a different identity provider <span class="login-err-username"><{0}></span> . Please <a class="instruction-link" href="#">sign out</a> if you want to continue.

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/messages/messages_en.properties
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/messages/messages_en.properties
@@ -5,3 +5,5 @@ loginTotpStep1=Install one of the following applications on your mobile, desktop
 configureTotpMessage=You need to set up either a mobile, desktop or browser authenticator to activate your account.
 missingTotpMessage=Please specify One-time code.
 kcLabelWrapperClass=col-md-4
+invalidFederatedIdentityActionMessage=You cannot log in to both IDIR and BCeID at the same time in one browser. Learn more <a href="#">here</a>.
+differentUserAuthenticated=You have authenticated/logged in with a different identity provider <span class="login-err-username"><{0}></span> . Please <a class="instruction-link" href="#">sign out</a> if you want to continue.

--- a/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/resources/js/script-20221128.js
+++ b/docker/keycloak/extensions-7.6/themes/src/main/resources/theme/bcgov/login/resources/js/script-20221128.js
@@ -9,6 +9,41 @@ document.addEventListener('DOMContentLoaded', function (event) {
   document.getElementById('kc-page-title').innerHTML = titleContent;
 
   addTooltips();
+
+  if (titleContent === 'Login Error:') {
+    if (
+      document.getElementsByClassName('login-err-username')[0] &&
+      document.getElementsByClassName('instruction-link')[0]
+    ) {
+      const pageURLQueryParams = new URLSearchParams(window.location.search);
+
+      const pageURLQueryParamsObject = {};
+
+      for (const [key, value] of pageURLQueryParams) {
+        pageURLQueryParamsObject[key] = value;
+      }
+
+      document.getElementsByClassName(
+        'instruction-link',
+      )[0].href = `${window.location.protocol}//${window.location.host}/auth/realms/standard/login-actions/restart?client_id=${pageURLQueryParamsObject?.client_id}&tab_id=${pageURLQueryParamsObject?.tab_id}`;
+
+      // Replace the username with the identity provider alias
+      const usernameRegex = /<[\w\d]+@(\w+)>/g;
+
+      const loginErrorString = document.getElementsByClassName('login-err-username')[0].innerText;
+
+      const updatedDifferentUserAuthenticatedMessage = loginErrorString.replace(
+        usernameRegex,
+        (match, capturedGroup) => {
+          // If a match is found, replace it with the captured group
+          // Otherwise, return the original match
+          return capturedGroup || match;
+        },
+      );
+
+      document.getElementsByClassName('login-err-username')[0].innerText = updatedDifferentUserAuthenticatedMessage;
+    }
+  }
 });
 
 function updateFavIcon() {


### PR DESCRIPTION
Below errors are customized:

1. differentUserAuthenticated
2. invalidFederatedIdentityActionMessage

Fixes [SSOTEAM-697](https://bcdevex.atlassian.net/browse/SSOTEAM-697)