### PR TITLE
chore: version

### DIFF
--- a/docker/kc-cron-job/Dockerfile
+++ b/docker/kc-cron-job/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
change to alpine node

I ran the built docker image locally for the zip-logs and dependencies are installing fine on alpine