### PR TITLE
chore: update metadata

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,6 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: "css-docs"
+  title: "Keycloak SSO Docs"
   description: "A guide to the BC Gov Common Hosted Single Sign-on"
   annotations:
     github.com/project-slug: bcgov/sso-keycloak


### PR DESCRIPTION
Hello! DevX is working to update the main landing page for techdocs to be more human readable (http://mvp.developer.gov.bc.ca/docs) 

Suggesting this would be clearer for users to find it in a big long list, but open to your edits