### PR TITLE
chore: migration

### DIFF
--- a/helm/kc-cron-job/migration.sql
+++ b/helm/kc-cron-job/migration.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 CREATE TABLE IF NOT EXISTS public.sso_logs (
   id serial NOT NULL,
   timestamp timestamp,
@@ -79,3 +81,5 @@ BEGIN
 END;
 $BODY$
 LANGUAGE 'plpgsql';
+
+END;


### PR DESCRIPTION
wrap sql migration in a transaction to prevent conflicting function creation error (see ticket 1184 for details).