### PR TITLE
chore: authenticator

### DIFF
--- a/docker/keycloak/extensions-7.6/services/pom.xml
+++ b/docker/keycloak/extensions-7.6/services/pom.xml
@@ -38,6 +38,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+                <configuration>
+                    <argLine>--illegal-access=permit</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -128,17 +136,30 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemover.java
+++ b/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemover.java
@@ -8,6 +8,9 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionProvider;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import java.util.Map;
 
 public class UserSessionRemover implements Authenticator {
 
@@ -20,17 +23,34 @@ public class UserSessionRemover implements Authenticator {
 
   @Override
   public void authenticate(AuthenticationFlowContext context) {
-
+    AuthenticationSessionModel session = context.getAuthenticationSession();
     AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(
-        context.getSession(), context.getRealm(), true);
+      context.getSession(),
+      context.getRealm(),
+      true
+    );
 
+    // 1. If no Cookie session, proceed to next step
     if (authResult == null) {
       context.attempted();
       return;
     }
 
-    UserSessionProvider userSessionProvider = context.getSession().sessions();
-    userSessionProvider.removeUserSession(context.getRealm(), authResult.getSession());
+    // Need to use the KeycloakSession context to get the authenticating client ID. Not available on the AuthenticationFlowContext.
+    KeycloakSession keycloakSession = context.getSession();
+    String authenticatingClientUUID = keycloakSession.getContext().getClient().getId();
+
+    // Get all existing sessions. If any session is associated with a different client, clear all user sessions.
+    UserSessionProvider userSessionProvider = keycloakSession.sessions();
+    Map<String, Long> activeClientSessionStats = userSessionProvider.getActiveClientSessionStats(context.getRealm(), false);
+
+    for (String activeSessionClientUUID : activeClientSessionStats.keySet()) {
+      if (!activeSessionClientUUID.equals(authenticatingClientUUID)) {
+        logger.info("REMOVING THE SESSIONS!");
+        userSessionProvider.removeUserSession(context.getRealm(), authResult.getSession());
+      }
+    }
+
     context.attempted();
   }
 

--- a/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemover.java
+++ b/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemover.java
@@ -1,0 +1,53 @@
+package com.github.bcgov.keycloak.authenticators;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionProvider;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.authentication.AuthenticationFlowContext;
+
+public class UserSessionRemover implements Authenticator {
+
+  private static final Logger logger = Logger.getLogger(UserSessionRemover.class);
+
+  @Override
+  public boolean requiresUser() {
+    return false;
+  }
+
+  @Override
+  public void authenticate(AuthenticationFlowContext context) {
+
+    AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(
+        context.getSession(), context.getRealm(), true);
+
+    if (authResult == null) {
+      context.attempted();
+      return;
+    }
+
+    UserSessionProvider userSessionProvider = context.getSession().sessions();
+    userSessionProvider.removeUserSession(context.getRealm(), authResult.getSession());
+    context.attempted();
+  }
+
+  @Override
+  public void action(AuthenticationFlowContext context) {
+  }
+
+  @Override
+  public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+    return true;
+  }
+
+  @Override
+  public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemover.java
+++ b/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemover.java
@@ -46,7 +46,6 @@ public class UserSessionRemover implements Authenticator {
 
     for (String activeSessionClientUUID : activeClientSessionStats.keySet()) {
       if (!activeSessionClientUUID.equals(authenticatingClientUUID)) {
-        logger.info("REMOVING THE SESSIONS!");
         userSessionProvider.removeUserSession(context.getRealm(), authResult.getSession());
       }
     }

--- a/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverFactory.java
+++ b/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverFactory.java
@@ -1,0 +1,82 @@
+package com.github.bcgov.keycloak.authenticators;
+
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.DisplayTypeAuthenticatorFactory;
+import org.keycloak.authentication.authenticators.AttemptedAuthenticator;
+import org.keycloak.models.AuthenticationExecutionModel.Requirement;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class UserSessionRemoverFactory
+    implements AuthenticatorFactory, DisplayTypeAuthenticatorFactory {
+
+  protected static final Requirement[] REQUIREMENT_CHOICES = {
+    Requirement.REQUIRED, Requirement.ALTERNATIVE, Requirement.DISABLED
+  };
+
+  @Override
+  public String getId() {
+    return "user-session-remover";
+  }
+
+  @Override
+  public String getDisplayType() {
+    return "User Session Remover";
+  }
+
+  @Override
+  public String getHelpText() {
+    return "Removes the user session.";
+  }
+
+  @Override
+  public Authenticator create(KeycloakSession session) {
+    return new UserSessionRemover ();
+  }
+
+  @Override
+  public Authenticator createDisplay(KeycloakSession session, String displayType) {
+    if (displayType == null) return new UserSessionRemover();
+    if (!OAuth2Constants.DISPLAY_CONSOLE.equalsIgnoreCase(displayType)) return null;
+    return AttemptedAuthenticator.SINGLETON; // ignore this authenticator
+  }
+
+  @Override
+  public Requirement[] getRequirementChoices() {
+    return REQUIREMENT_CHOICES;
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return null;
+  }
+
+  @Override
+  public String getReferenceCategory() {
+    return null;
+  }
+
+  @Override
+  public boolean isConfigurable() {
+    return false;
+  }
+
+  @Override
+  public boolean isUserSetupAllowed() {
+    return true;
+  }
+
+  @Override
+  public void init(Config.Scope config) {}
+
+  @Override
+  public void postInit(KeycloakSessionFactory factory) {}
+
+  @Override
+  public void close() {}
+}

--- a/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverFactory.java
+++ b/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverFactory.java
@@ -32,7 +32,7 @@ public class UserSessionRemoverFactory implements AuthenticatorFactory {
 
   @Override
   public String getHelpText() {
-    return "Removes the user session.";
+    return "Checks if the user session is realted to any other client, and removes it if so.";
   }
 
   @Override

--- a/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverFactory.java
+++ b/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverFactory.java
@@ -12,12 +12,13 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 
-public class UserSessionRemoverFactory
-    implements AuthenticatorFactory, DisplayTypeAuthenticatorFactory {
+public class UserSessionRemoverFactory implements AuthenticatorFactory {
 
   protected static final Requirement[] REQUIREMENT_CHOICES = {
     Requirement.REQUIRED, Requirement.ALTERNATIVE, Requirement.DISABLED
   };
+
+  private static final Authenticator AUTHENTICATOR_INSTANCE = new UserSessionRemover();
 
   @Override
   public String getId() {
@@ -36,14 +37,7 @@ public class UserSessionRemoverFactory
 
   @Override
   public Authenticator create(KeycloakSession session) {
-    return new UserSessionRemover ();
-  }
-
-  @Override
-  public Authenticator createDisplay(KeycloakSession session, String displayType) {
-    if (displayType == null) return new UserSessionRemover();
-    if (!OAuth2Constants.DISPLAY_CONSOLE.equalsIgnoreCase(displayType)) return null;
-    return AttemptedAuthenticator.SINGLETON; // ignore this authenticator
+    return AUTHENTICATOR_INSTANCE;
   }
 
   @Override

--- a/docker/keycloak/extensions-7.6/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/docker/keycloak/extensions-7.6/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -3,5 +3,6 @@ com.github.bcgov.keycloak.authenticators.CookieStopAuthenticatorFactory
 com.github.bcgov.keycloak.authenticators.ClientLoginAuthenticatorFactory
 com.github.bcgov.keycloak.authenticators.ClientLoginRoleBindingFactory
 com.github.bcgov.keycloak.authenticators.UserAttributeAuthenticatorFactory
+com.github.bcgov.keycloak.authenticators.UserSessionRemoverFactory
 com.github.bcgov.keycloak.authenticators.broker.IdpDeleteUserIfDuplicateAuthenticatorFactory
 com.github.bcgov.keycloak.authenticators.browser.IdentityProviderStopFormFactory

--- a/docker/keycloak/extensions-7.6/services/src/test/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverTest.java
+++ b/docker/keycloak/extensions-7.6/services/src/test/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverTest.java
@@ -1,6 +1,5 @@
 package com.github.bcgov.keycloak.testsuite.authenticators;
 
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,14 +11,11 @@ import org.mockito.MockedStatic;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 
-import org.jboss.logging.Logger;
 import com.github.bcgov.keycloak.authenticators.UserSessionRemover;
 import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.authentication.Authenticator;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.services.managers.AuthenticationManager;
-import org.keycloak.models.UserModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.models.UserSessionProvider;

--- a/docker/keycloak/extensions-7.6/services/src/test/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverTest.java
+++ b/docker/keycloak/extensions-7.6/services/src/test/java/com/github/bcgov/keycloak/authenticators/UserSessionRemoverTest.java
@@ -1,0 +1,144 @@
+package com.github.bcgov.keycloak.testsuite.authenticators;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.mockito.Mockito;
+import org.mockito.MockedStatic;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.jboss.logging.Logger;
+import com.github.bcgov.keycloak.authenticators.UserSessionRemover;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.models.UserSessionProvider;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.KeycloakContext;
+import java.util.HashMap;
+import java.util.Map;
+
+public class UserSessionRemoverTest {
+  private static final UserSessionRemover userSessionRemover = new UserSessionRemover();
+
+  private AuthenticationFlowContext context;
+  private KeycloakSession session;
+  private RealmModel realm;
+  private AuthenticationSessionModel authSession;
+  private UserSessionProvider userSessionProvider;
+  private KeycloakSession keycloakSession;
+  private ClientModel client;
+  private KeycloakContext keycloakContext;
+  private AuthenticationManager.AuthResult authResult;
+
+  @BeforeEach
+  public void setup() {
+      // Initialize mocks for necessary objects
+      context = mock(AuthenticationFlowContext.class);
+      realm = mock(RealmModel.class);
+      authSession = mock(AuthenticationSessionModel.class);
+      userSessionProvider = mock(UserSessionProvider.class);
+      keycloakSession = mock(KeycloakSession.class);
+      keycloakContext = mock(KeycloakContext.class);
+      client = mock(ClientModel.class);
+      authResult = mock(AuthenticationManager.AuthResult.class);
+
+      // Set up common behavior of the mocks
+      when(context.getSession()).thenReturn(keycloakSession);
+      when(context.getRealm()).thenReturn(realm);
+      when(context.getAuthenticationSession()).thenReturn(authSession);
+      when(keycloakSession.sessions()).thenReturn(userSessionProvider);
+      when(context.getSession()).thenReturn(keycloakSession);
+      when(keycloakSession.getContext()).thenReturn(keycloakContext);
+      when(keycloakContext.getClient()).thenReturn(client);
+      when(authResult.getSession()).thenReturn(mock(UserSessionModel.class));
+  }
+
+  @Test
+  public void testSkipClientSessionCheckWhenNullAuthResult() throws Exception {
+    try (MockedStatic<AuthenticationManager> authenticationManager = Mockito.mockStatic(AuthenticationManager.class)) {
+      authenticationManager.when(() -> AuthenticationManager.authenticateIdentityCookie(
+        any(KeycloakSession.class), any(RealmModel.class), any(Boolean.class)
+      )).thenReturn(null);
+      userSessionRemover.authenticate(context);
+
+      // Keycloak Session Context check skipped if no Auth Session
+      verify(keycloakSession, times(0)).getContext();
+      verify(userSessionProvider, times(0)).removeUserSession(any(RealmModel.class), any(UserSessionModel.class));
+    }
+  }
+
+  @Test
+  public void testRemovesUserSessionsWhenMultipleClientSessionsExist() throws Exception {
+    when(client.getId()).thenReturn("client1");
+    Map<String, Long> activeClientSessionStats = new HashMap<>();
+    activeClientSessionStats.put("client1", 1L);
+    activeClientSessionStats.put("client2", 2L);
+
+    when(userSessionProvider.getActiveClientSessionStats(any(RealmModel.class), any(Boolean.class))).thenReturn(activeClientSessionStats);
+
+    try (MockedStatic<AuthenticationManager> authenticationManager = Mockito.mockStatic(AuthenticationManager.class)) {
+      authenticationManager.when(() -> AuthenticationManager.authenticateIdentityCookie(
+        any(KeycloakSession.class), any(RealmModel.class), any(Boolean.class)
+      )).thenReturn(authResult);
+
+      userSessionRemover.authenticate(context);
+
+      verify(keycloakSession, times(1)).getContext();
+      verify(userSessionProvider, times(1)).removeUserSession(any(RealmModel.class), any(UserSessionModel.class));
+    }
+  }
+
+  @Test
+  public void testRemovesUserSessionsWhenSingleDifferentClientSessionFound() throws Exception {
+    when(client.getId()).thenReturn("client1");
+    Map<String, Long> activeClientSessionStats = new HashMap<>();
+    activeClientSessionStats.put("client2", 2L);
+
+    when(userSessionProvider.getActiveClientSessionStats(any(RealmModel.class), any(Boolean.class))).thenReturn(activeClientSessionStats);
+
+    try (MockedStatic<AuthenticationManager> authenticationManager = Mockito.mockStatic(AuthenticationManager.class)) {
+      authenticationManager.when(() -> AuthenticationManager.authenticateIdentityCookie(
+        any(KeycloakSession.class), any(RealmModel.class), any(Boolean.class)
+      )).thenReturn(authResult);
+      userSessionRemover.authenticate(context);
+
+      verify(keycloakSession, times(1)).getContext();
+      verify(userSessionProvider, times(1)).removeUserSession(any(RealmModel.class), any(UserSessionModel.class));
+    }
+  }
+
+  @Test
+  public void testLeavesExistingSessionWhenOnlyAssociatedToAuthenticatingClient() throws Exception {
+    when(client.getId()).thenReturn("client1");
+    Map<String, Long> activeClientSessionStats = new HashMap<>();
+
+    // Only active session matches authenticating client
+    activeClientSessionStats.put("client1", 1L);
+
+    when(userSessionProvider.getActiveClientSessionStats(any(RealmModel.class), any(Boolean.class))).thenReturn(activeClientSessionStats);
+
+    try (MockedStatic<AuthenticationManager> authenticationManager = Mockito.mockStatic(AuthenticationManager.class)) {
+      authenticationManager.when(() -> AuthenticationManager.authenticateIdentityCookie(
+        any(KeycloakSession.class), any(RealmModel.class), any(Boolean.class)
+      )).thenReturn(authResult);
+      userSessionRemover.authenticate(context);
+
+      // Verify the keycloak session context is invoked to check client sessions
+      verify(keycloakSession, times(1)).getContext();
+
+      // Remove user session should be skipped
+      verify(userSessionProvider, times(0)).removeUserSession(any(RealmModel.class), any(UserSessionModel.class));
+    }
+  }
+}


### PR DESCRIPTION
Add authenticator to remove sessions based on client check. Basic logic is if I have an active session with any client other than the one I am currently authenticating with, remove my user session. If my session is only linked to the current client, let it be. 

I spent some time updating the unit test setup, for the new tests I needed to bump Mockito so that mocking static methods was possible, and the maven-surefire-plugin was needed to use jupiter which has some nice annotations (mainly @BeforeEach).

The new unit test dependencies have `<scope>test</scope>` so they will get excluded from the production build. Just mentioning this because I am not as familiar with the Java build process so pointing it out for review.  