### PR TITLE
fix: session remover

### DIFF
--- a/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemover.java
+++ b/docker/keycloak/extensions-7.6/services/src/main/java/com/github/bcgov/keycloak/authenticators/UserSessionRemover.java
@@ -6,9 +6,11 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionProvider;
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.models.UserSessionModel;
 
 import java.util.Map;
 
@@ -23,34 +25,31 @@ public class UserSessionRemover implements Authenticator {
 
   @Override
   public void authenticate(AuthenticationFlowContext context) {
-    AuthenticationSessionModel session = context.getAuthenticationSession();
-    AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(
-      context.getSession(),
-      context.getRealm(),
-      true
-    );
 
-    // 1. If no Cookie session, proceed to next step
+    UserSessionModel userSessionModel;
+    AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(context.getSession(), context.getRealm(), true);
+
     if (authResult == null) {
       context.attempted();
       return;
     }
 
-    // Need to use the KeycloakSession context to get the authenticating client ID. Not available on the AuthenticationFlowContext.
-    KeycloakSession keycloakSession = context.getSession();
-    String authenticatingClientUUID = keycloakSession.getContext().getClient().getId();
+    userSessionModel = authResult.getSession();
 
-    // Get all existing sessions. If any session is associated with a different client, clear all user sessions.
-    UserSessionProvider userSessionProvider = keycloakSession.sessions();
-    Map<String, Long> activeClientSessionStats = userSessionProvider.getActiveClientSessionStats(context.getRealm(), false);
+    String authenticatingClientUUID = context.getSession().getContext().getClient().getId();
+    UserSessionProvider userSessionProvider = context.getSession().sessions();
 
-    for (String activeSessionClientUUID : activeClientSessionStats.keySet()) {
+    // Must fetch sessions from the user session model, user session provider has all session in the realm
+    Map<String, AuthenticatedClientSessionModel> authenticatedClientSessions = userSessionModel.getAuthenticatedClientSessions();
+
+    for (String activeSessionClientUUID : authenticatedClientSessions.keySet()) {
       if (!activeSessionClientUUID.equals(authenticatingClientUUID)) {
         userSessionProvider.removeUserSession(context.getRealm(), authResult.getSession());
       }
     }
 
     context.attempted();
+    return;
   }
 
   @Override


### PR DESCRIPTION
check only user sessions not realm sessions. In the previous code, I had thought that `context.getSession().sessions().getActiveClientSessionStats` was getting the client sessions for the current user session in context. The method actually is returning the active client sessions counts across the realm. Meaning if any other client is logged into by any other user, the current user session gets turfed.

Updating to use the `getAuthenticatedClientSessions()` method on the [UserSessionModel](https://www.keycloak.org/docs-api/21.1.1/javadocs/org/keycloak/models/UserSessionModel.html#getAuthenticatedClientSessions()) instead.