### PR TITLE
chore: network policy

### DIFF
--- a/helm/kc-cron-job/templates/network-policy.yaml
+++ b/helm/kc-cron-job/templates/network-policy.yaml
@@ -81,3 +81,24 @@ spec:
               name: {{ .Values.networkPolicy.licensePlate }}
   policyTypes:
     - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: kc-cronjob-same-namespace
+  namespace: {{ .Values.networkPolicy.licensePlate }}-tools
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{.Values.nameOverride}}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{.Values.nameOverride}}
+          namespaceSelector:
+            matchLabels:
+              environment: tools
+              name: {{ .Values.networkPolicy.licensePlate }}
+  policyTypes:
+    - Ingress

--- a/helm/kc-cron-job/values-c6af30-tools.yaml
+++ b/helm/kc-cron-job/values-c6af30-tools.yaml
@@ -11,11 +11,11 @@ fullnameOverride: kc-cron-job
 
 enableEventLogsJob: true
 
-enableActiveSessionsJob: false
+enableActiveSessionsJob: true
 
-enableRemoveInactiveUsersJob: false
+enableRemoveInactiveUsersJob: true
 
-enableRemoveVcUsersJob: false
+enableRemoveVcUsersJob: true
 
 namespace:
   eventLogs:


### PR DESCRIPTION
In the e4ca1d-tools/eb75ad-tools namespaces there is a network policy "allow-same-namespace", pretty sure this was added manually not from any helm chart, the only reference I found to it was in the metabase charts readme but just saying to ensure they exist . It is needed for the cronjob pods in the tools namespace to talk to the patroni instance there, so I added a policy to the kc-cron-job chart to cover this so it would be in helm. I tightened it up a bit to just select patroni and the cron-job-pods instead of all pods in the namespace, figure if we're allowing more traffic later pods can have their own network policies.

This also enables the cronjobs in the c6 helm chart to test them out, they seem to be running well there.