### PR TITLE
chore: expiry view

### DIFF
--- a/docker/otp-provider/e2e/otp.spec.ts
+++ b/docker/otp-provider/e2e/otp.spec.ts
@@ -114,3 +114,24 @@ test('OTP Success', async ({ page }, testInfo) => {
   verifiedOTPEvents = await eventModel.findAll({ where: { eventType: 'OTP_VERIFIED', email, clientId } });
   expect(verifiedOTPEvents.length).toBe(1);
 });
+
+test('OTP Expired', async ({ page }, testInfo) => {
+  await page.goto(initURL);
+  const email = `${testInfo.project.name}@b.com`;
+
+  // Enter email and go to OTP page
+  await page.getByRole('textbox', { name: 'Email' }).fill(email);
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.waitForURL('**/otp');
+
+  const currentOtp = await otpModel
+    .findOne({ where: { email: `${testInfo.project.name}@b.com`, active: true } });
+
+  // Set OTP timestamp to make it expired
+  const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+  await otpModel.update({createdAt: fiveMinutesAgo}, {where: {id: currentOtp.id}} );
+
+  // assert filling in otp creates event
+  await fillOTP(currentOtp.otp, false, page);
+  await expect(page.locator('body')).toMatchAriaSnapshot(`- paragraph: The verification code sent to ${email} has expired after five minutes.`);
+});

--- a/docker/otp-provider/src/controllers/auth-controller.ts
+++ b/docker/otp-provider/src/controllers/auth-controller.ts
@@ -142,7 +142,9 @@ export const login = async (oidcProvider: Provider) => {
 
         const { waitTime, error } = await verifyOtp(email, otp as string, clientID as string, delayMultiplier);
         if (error) {
-          return res.render('otp', {
+          // Expiry page has a customized view, all others use the default.
+          const view = error === 'EXPIRED_OTP' ? 'expired' : 'otp';
+          return res.render(view, {
             uid,
             email,
             nonce: res.locals.cspNonce,

--- a/docker/otp-provider/src/modules/errors.ts
+++ b/docker/otp-provider/src/modules/errors.ts
@@ -4,6 +4,8 @@ export const errors = {
   INVALID_EMAIL: 'Invalid email.',
   EXPIRED_OTP_WITH_RESEND: `You've tried too many times. Please send a new code.`,
   INVALID_OTP: 'Invalid code entered. Please try again or send a new code.',
+  // Expired OTP error has a customized view
+  EXPIRED_OTP: '',
 };
 
 type Errors = typeof errors;

--- a/docker/otp-provider/src/modules/sequelize/migrations/017_create_events_table.ts
+++ b/docker/otp-provider/src/modules/sequelize/migrations/017_create_events_table.ts
@@ -199,7 +199,10 @@ export const up = async (queryInterface: QueryInterface) => {
         INSERT INTO "Event" (email, "clientId", "eventType", timestamp)
         VALUES (email_input, client_id, 'INVALID_OTP', NOW()), (email_input, client_id, 'MAX_ATTEMPTS', NOW());
 
-        RETURN QUERY SELECT false, wait_seconds, 'EXPIRED_OTP_WITH_RESEND';
+        RETURN QUERY SELECT
+          false,
+          CASE WHEN can_request THEN 0 ELSE wait_seconds END,
+          'EXPIRED_OTP_WITH_RESEND';
         RETURN;
       END IF;
 
@@ -212,7 +215,10 @@ export const up = async (queryInterface: QueryInterface) => {
         INSERT INTO "Event" (email, "clientId", "eventType", timestamp)
         VALUES (email_input, client_id, 'INVALID_OTP', NOW());
 
-        RETURN QUERY SELECT false, wait_seconds, 'INVALID_OTP';
+        RETURN QUERY SELECT
+          false,
+          CASE WHEN can_request THEN 0 ELSE wait_seconds END,
+          'INVALID_OTP';
         RETURN;
       END IF;
 
@@ -221,7 +227,10 @@ export const up = async (queryInterface: QueryInterface) => {
         INSERT INTO "Event" (email, "clientId", "eventType", timestamp)
         VALUES (email_input, client_id, 'EXPIRED_OTP', NOW());
 
-        RETURN QUERY SELECT false, wait_seconds, 'EXPIRED_OTP';
+        RETURN QUERY SELECT
+          false,
+          CASE WHEN can_request THEN 0 ELSE wait_seconds END,
+          'EXPIRED_OTP';
         RETURN;
       END IF;
 


### PR DESCRIPTION
- Add back the custom expired view when the error code matches
- Update the wait time in validate_otp to be 0 if able te request immediately

I am updating the function in the initial migration since we are not live instead of a new file, makes the diff easy, I will update the function in the sandbox db