### PR TITLE
chore: default perms

### DIFF
--- a/docker/keycloak/configuration/26/keycloak-default-user-profile.json
+++ b/docker/keycloak/configuration/26/keycloak-default-user-profile.json
@@ -1,12 +1,12 @@
 {
-  "unmanagedAttributePolicy": "ENABLED",
+  "unmanagedAttributePolicy": "ADMIN_EDIT",
   "attributes": [
     {
       "name": "username",
       "displayName": "${username}",
       "permissions": {
-        "view": ["admin", "user"],
-        "edit": ["admin", "user"]
+        "view": ["admin"],
+        "edit": ["admin"]
       },
       "validations": {
         "length": { "min": 3, "max": 255 },
@@ -18,8 +18,8 @@
       "name": "email",
       "displayName": "${email}",
       "permissions": {
-        "view": ["admin", "user"],
-        "edit": ["admin", "user"]
+        "view": ["admin"],
+        "edit": ["admin"]
       },
       "validations": {
         "email": {},
@@ -30,8 +30,8 @@
       "name": "firstName",
       "displayName": "${firstName}",
       "permissions": {
-        "view": ["admin", "user"],
-        "edit": ["admin", "user"]
+        "view": ["admin"],
+        "edit": ["admin"]
       },
       "validations": {
         "length": { "max": 255 },
@@ -42,8 +42,8 @@
       "name": "lastName",
       "displayName": "${lastName}",
       "permissions": {
-        "view": ["admin", "user"],
-        "edit": ["admin", "user"]
+        "view": ["admin"],
+        "edit": ["admin"]
       },
       "validations": {
         "length": { "max": 255 },


### PR DESCRIPTION
Update default permissions to admin only edit. Right now, if manage-account role is assigned to a user, the default profile allows edit for users for all attributes. Tightening this to admin only edit, as the default case for us is to have all attributes sync from upstream IDPs. I removed view as well, so the user would just see an empty screen if given manage-account. Realms can override this default profile if they want to allow editing.

I checked profile update won't be affected by a change to the default profile, so any customizations will stay in place.