### PR TITLE
chore: bump java version

### DIFF
--- a/docker/keycloak/Dockerfile-26
+++ b/docker/keycloak/Dockerfile-26
@@ -1,4 +1,4 @@
-FROM maven:3.9.12-eclipse-temurin-21 AS extensions-builder
+FROM maven:3.9.16-eclipse-temurin-21 AS extensions-builder
 
 COPY ./extensions-26 /tmp/
 WORKDIR /tmp/

--- a/docker/keycloak/Dockerfile-26-perf
+++ b/docker/keycloak/Dockerfile-26-perf
@@ -1,4 +1,4 @@
-FROM maven:3.9.12-eclipse-temurin-21 AS extensions-builder
+FROM maven:3.9.16-eclipse-temurin-21 AS extensions-builder
 
 COPY ./extensions-26 /tmp/
 WORKDIR /tmp/

--- a/docker/keycloak/extensions-26/pom.xml
+++ b/docker/keycloak/extensions-26/pom.xml
@@ -8,8 +8,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <keycloak.version>26.6.4</keycloak.version>
         <java.version>21</java.version>

--- a/docker/keycloak/extensions-26/services/pom.xml
+++ b/docker/keycloak/extensions-26/services/pom.xml
@@ -43,8 +43,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
move java version to 21. The redhat base dockerfile [uses jdk-21](https://catalog.redhat.com/en/software/containers/rhbk/keycloak-rhel9/64f0add883a29ec473d40906?image=6a39ad0f06e759f52eebba97&architecture=s390x#containerfile) so still to early to go all the way to 25